### PR TITLE
Error on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "devDependencies": {
     "autoprefixer-core": "^6.0.1",
-    "babel": "^6.5.2",
+    "babel-cli": "^6.5.2",
     "babel-core": "^6.9.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
```
npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.12
npm ERR! Windows_NT 10.0.10586
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install"
npm ERR! node v5.7.1
npm ERR! npm  v3.6.0
npm ERR! code ELIFECYCLE
npm ERR! react-slick@0.12.2 prepublish: `babel ./src --out-dir ./lib && gulp dist`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-slick@0.12.2 prepublish script 'babel ./src --out-dir ./lib && gulp dist'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the react-slick package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     babel ./src --out-dir ./lib && gulp dist
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs react-slick
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls react-slick
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     D:\vitamin\hofi\homefinders\webapp\node_modules\react-slick\npm-debug.log
```
